### PR TITLE
IV random and non-secret

### DIFF
--- a/keys.txt
+++ b/keys.txt
@@ -1,5 +1,4 @@
 #{appsecret  => "Replace this with your own appsecret",
   cryptkey   => <<"abcdefghabcdefgh">>,
-  initvec    => <<"12345678abcdefgh">>,
   soundcloud => "Add your soundcloud API key"
  }.


### PR DESCRIPTION
I was looking at your web server, really nice one Kristian!

My small contribution here. See what kind of attack is possible with your current approach:

3> crypto:block_encrypt(aes_cfb128, <<"1234567812345678">>, <<"8765432187654321">>, <<"kristianx">>). 
<<251,153,102,48,62,234,192,207,194>>
4> crypto:block_encrypt(aes_cfb128, <<"1234567812345678">>, <<"8765432187654321">>, <<"kristian">>). 
<<251,153,102,48,62,234,192,207>>

So just register a longer username and take off a few symbols, and you get someone's cookie. The user must be logged in though, but one should only pick the right time.
 
With random IV you will get a different ciphertext every time, that's the point. IV is generally not secret, so you can just send it over to client.